### PR TITLE
Pi/special cap

### DIFF
--- a/calculation/calculation.go
+++ b/calculation/calculation.go
@@ -244,7 +244,7 @@ func isPoolQualified(program types.Program, pool types.Pool, locked uint64) (boo
 	if program.DisqualifiedPairs != nil {
 		for _, pair := range program.DisqualifiedPairs {
 			if pair.AssetA == pool.AssetA && pair.AssetB == pool.AssetB {
-				qualified = true
+				qualified = false
 				reason += "Pair is explicitly disqualified; "
 			}
 		}

--- a/calculation/calculation.go
+++ b/calculation/calculation.go
@@ -195,6 +195,7 @@ func isPoolQualified(program types.Program, pool types.Pool, locked uint64) (boo
 			if poolIdent == pool.PoolIdent {
 				qualified = true
 				found = true
+				break
 			}
 		}
 		if !found {
@@ -207,6 +208,7 @@ func isPoolQualified(program types.Program, pool types.Pool, locked uint64) (boo
 			if assetID == pool.AssetA || assetID == pool.AssetB {
 				qualified = true
 				found = true
+				break
 			}
 		}
 		if !found {
@@ -219,6 +221,7 @@ func isPoolQualified(program types.Program, pool types.Pool, locked uint64) (boo
 			if pair.AssetA == pool.AssetA && pair.AssetB == pool.AssetB {
 				qualified = true
 				found = true
+				break
 			}
 		}
 		if !found {
@@ -230,6 +233,7 @@ func isPoolQualified(program types.Program, pool types.Pool, locked uint64) (boo
 			if poolIdent == pool.PoolIdent {
 				qualified = false
 				reason += "Pool is explicitly disqualified; "
+				break
 			}
 		}
 	}
@@ -238,6 +242,7 @@ func isPoolQualified(program types.Program, pool types.Pool, locked uint64) (boo
 			if assetID == pool.AssetA || assetID == pool.AssetB {
 				qualified = false
 				reason += "One of the assets in this pool is explicitly disqualified; "
+				break
 			}
 		}
 	}
@@ -246,6 +251,7 @@ func isPoolQualified(program types.Program, pool types.Pool, locked uint64) (boo
 			if pair.AssetA == pool.AssetA && pair.AssetB == pool.AssetB {
 				qualified = false
 				reason += "Pair is explicitly disqualified; "
+				break
 			}
 		}
 	}

--- a/calculation/calculation.go
+++ b/calculation/calculation.go
@@ -413,7 +413,7 @@ func DistributeEmissionsToPools(program types.Program, poolsReceivingEmissionsBy
 
 	// No pool has received weight
 	// We then divide the daily emissions among these pools in proportion to their weight, rounding down
-	if totalWeight == 0 && len(program.FixedEmissions) == 0 {
+	if totalWeight == 0 {
 		return emissionsByPool
 	}
 
@@ -450,6 +450,16 @@ func DistributeEmissionsToPools(program types.Program, poolsReceivingEmissionsBy
 		if allocatedEmissions != program.DailyEmission {
 			// There's a bug in the round-robin distribution code, panic so we fix the bug
 			panic("round-robin distribution wasn't succesful")
+		}
+	}
+
+	// Now check to make sure none of these pools (other than the fixed emissions) exceed the cap on daily emissions per pool
+	if program.EmissionCap != 0 {
+		for pool, amount := range emissionsByPool {
+			_, ok := program.FixedEmissions[pool]
+			if !ok && amount > program.EmissionCap {
+				emissionsByPool[pool] = program.EmissionCap
+			}
 		}
 	}
 

--- a/calculation/calculation.go
+++ b/calculation/calculation.go
@@ -184,9 +184,9 @@ func isPoolQualified(program types.Program, pool types.Pool, locked uint64) (boo
 		return false, fmt.Sprintf("less than %v%% of LP tokens locked", program.MinLPIntegerPercent)
 	}
 	// We'll use a true/false striping to allow/disallow this pool
-	// if it's in the eligible pools, or has an asset that's in the eligible assets, we'll flip it true
-	// if it's in the disqualified pools, or disqualified assets, we'll flip it back false
-	// BUT, if eligible pools and eligible assets are both nil, then we'll assume it's true unless disqualified
+	// if it's covered by one of the "eligible" criteria, we'll flip it true
+	// if it's covered by one of the "disqualified" criteria, we'll flip it back false
+	// BUT, if the "eligible" criteria lists are all null, then every pool starts eligible, so this needs to start true
 	qualified := program.EligiblePools == nil && program.EligibleAssets == nil && program.EligiblePairs == nil
 	reason := ""
 	if program.EligiblePools != nil {

--- a/calculation/calculation_test.go
+++ b/calculation/calculation_test.go
@@ -400,13 +400,20 @@ func Test_EmissionsToPools(t *testing.T) {
 		"C": 1000,
 	})
 	assert.EqualValues(t, map[string]uint64{"A": 166_333_333_333, "B": 332_666_666_667, "C": 1_000_000_000}, emissions)
+}
 
+func Test_TruncateEmissions(t *testing.T) {
+	program := sampleProgram(500_000_000_000)
 	program.EmissionCap = 200_000_000_000
-	emissions = DistributeEmissionsToPools(program, map[string]uint64{
+	program.FixedEmissions = map[string]uint64{
+		"C": 1_000_000_000,
+	}
+	rawEmissions := DistributeEmissionsToPools(program, map[string]uint64{
 		"A": 1000,
 		"B": 2000,
 	})
-	assert.EqualValues(t, map[string]uint64{"A": 166_333_333_333, "B": 200_000_000_000, "C": 1_000_000_000}, emissions)
+	truncatedEmissions := TruncateEmissions(program, rawEmissions)
+	assert.EqualValues(t, map[string]uint64{"A": 166_333_333_333, "B": 200_000_000_000, "C": 1_000_000_000}, truncatedEmissions)
 }
 
 func Test_OwnerByLPAndAsset(t *testing.T) {

--- a/calculation/calculation_test.go
+++ b/calculation/calculation_test.go
@@ -390,6 +390,16 @@ func Test_EmissionsToPools(t *testing.T) {
 		"B": 2000,
 	})
 	assert.EqualValues(t, map[string]uint64{"A": 166_666_666_666, "B": 333_333_333_334}, emissions)
+
+	program.FixedEmissions = map[string]uint64{
+		"C": 1_000_000_000,
+	}
+	emissions = DistributeEmissionsToPools(program, map[string]uint64{
+		"A": 1000,
+		"B": 2000,
+		"C": 1000,
+	})
+	assert.EqualValues(t, map[string]uint64{"A": 166_333_333_333, "B": 332_666_666_667, "C": 1_000_000_000}, emissions)
 }
 
 func Test_OwnerByLPAndAsset(t *testing.T) {

--- a/types/types.go
+++ b/types/types.go
@@ -25,9 +25,37 @@ type Program struct {
 
 	EarningExpiration *time.Duration
 
-	EligiblePools     []string
+	// Any pools that received a fixed emission
+	// for example, pool 08 receives exactly 133234.5 tokens per day
+	// (30% of the daily emissions of 444115)
+	FixedEmissions map[string]uint64
+
+	// The maximum emissions, outside of the fixed emissions above,
+	// that any pool may receive for its delegation
+	// For example, this is set to 62176.1, as 14% of 444115
+	// Any remaining emissions above this are *not* emitted, and instead rever to the treasury
+	PercentageCap uint64
+
+	// A list of pools for which a delegation is considered valid
+	EligiblePools []string
+	// A list of assets for which *any* pools will be considered valid
+	EligibleAssets []chainsync.AssetID
+	// A list of assets, for which *any* pool with these two assets will be considered valid
+	EligiblePairs []struct {
+		AssetA chainsync.AssetID
+		AssetB chainsync.AssetID
+	}
+	// A list of pools for which delegation will be ignored
 	DisqualifiedPools []string
-	NepotismPools     []string
+	// A list of assets, for which *any* pools will be considered invalid
+	DisqualifiedAssets []chainsync.AssetID
+	// A list of assets, for which *any* pool with these two assets will be considered invalid
+	DisqualifiedPairs []struct {
+		AssetA chainsync.AssetID
+		AssetB chainsync.AssetID
+	}
+	// A list of pools which are automatically considered to have crossed the percentile threshold
+	NepotismPools []string
 
 	MinLPIntegerPercent   int
 	MaxPoolCount          int

--- a/types/types.go
+++ b/types/types.go
@@ -34,7 +34,7 @@ type Program struct {
 	// that any pool may receive for its delegation
 	// For example, this is set to 62176.1, as 14% of 444115
 	// Any remaining emissions above this are *not* emitted, and instead rever to the treasury
-	PercentageCap uint64
+	EmissionCap uint64
 
 	// A list of pools for which a delegation is considered valid
 	EligiblePools []string


### PR DESCRIPTION
Implements controls to configure the scheme specified in this governance proposal:

https://governance.sundaeswap.finance/#/proposal#3073216b94547c3737246d5a6c2190e475cd71a00fafa8f7b753704898a942ec

In particular, this adds:
- EligibleAssets, EligiblePairs, DisqualifiedAssets, and DisqualifiedPairs
  - These give more controls for flagging pools as eligible or disqualified, so that SUNDAE/ADA pools can be disqualified
  - Technically, only the last one is needed, but I added the others for symmetry and flexibility
- FixedEmissions
  - This map defines which pools receive a fixed, constant amount of tokens, as opposed to the normal delegation based weight
  - This will be used to give pool 08 a fixed 30% of the daily emissions
- EmissionCap
  - This property defines a fixed upper limit on how much any pool receiving delegation-based emissions can receive
  - For example, this will be set to 14% of the daily emissions, which would mean anything receiving more than that would have the surplus returned to the treasury

Ultimately, this exact implementation and the choice of settings will need to be ratified via another governance proposal, since the first one was underspecified, but I believe this fairly closely implements the behavior outlined in that proposal.